### PR TITLE
Fix Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,10 +37,12 @@ pre-build:
 post-build: release
 	rm ./linalg.c
 	rm ./linalg.h
+	rm -r ./$(OBJS_DIR)
 
 failed:	
 	-rm ./linalg.c
 	-rm ./linalg.h
+	-rm -r ./$(OBJS_DIR)
 #### static library fix end ####
 
 release: $(EXE_DIR)/$(EXE_FACEREC)


### PR DESCRIPTION
### Fixes #7 

### Highlevel overview of the changes
Makefile will now delete .obj directory upon post-build

### Changes proposed in this pull request:
- Makefile calls rm -r  $(OBJS_DIR)
