### PR TITLE
Fix makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -46,8 +46,14 @@ failed:
 #### static library fix end ####
 
 release: $(EXE_DIR)/$(EXE_FACEREC)
+
 debug: clean
-	($(MAKE) --no-print-directory pre-build && $(MAKE) --no-print-directory $(EXE_DIR)/$(EXE_FACEREC:%=%-debug)) || $(MAKE) --no-print-directory failed
+	($(MAKE) --no-print-directory pre-build && $(MAKE) --no-print-directory post-build-debug) || $(MAKE) --no-print-directory failed
+
+post-build-debug: $(EXE_DIR)/$(EXE_FACEREC:%=%-debug)
+	rm ./linalg.c
+	rm ./linalg.h
+	rm -r ./$(OBJS_DIR)	
 
 ## OBJECTS
 -include $(OBJS_DIR)/*.d
@@ -68,6 +74,8 @@ $(EXE_DIR)/$(EXE_FACEREC): $(OBJS_FACEREC:%.o=$(OBJS_DIR)/%-release.o)
 
 $(EXE_DIR)/$(EXE_FACEREC)-debug: $(OBJS_FACEREC:%.o=$(OBJS_DIR)/%-debug.o)
 	$(LD) $^ $(LDFLAGS) -o $@
+
+
 
 
 ## CLEAN


### PR DESCRIPTION
### Fixes #11 

### Highlevel overview of the changes
Makefile will now clean up its objects and source files created during compile time

### Changes proposed in this pull request:
- Makefile will behave the same way it does for release when building debug
- specifically in src/ linalg.c and linalg.h will be removed after build is finished
